### PR TITLE
Feature: Tour view

### DIFF
--- a/Walk Munich/Core/Data/Model/Tour.swift
+++ b/Walk Munich/Core/Data/Model/Tour.swift
@@ -1,0 +1,42 @@
+//
+//  Tour.swift
+//  Walk Munich
+//
+
+import Foundation
+
+struct TourSummary: Codable, Identifiable {
+    let id: Int64
+    let title: String
+    let summary: String?
+    let imageUrl: String?
+}
+
+struct ToursResponse: Codable {
+    let cityId: Int64
+    let routes: [TourSummary]
+}
+
+struct TourDetail: Codable, Identifiable {
+    let id: Int64
+    let cityId: Int64
+    let title: String
+    let segments: [TourSegment]
+    let imageUrl: String?
+    let summary: String?
+    let updatedAt: String
+}
+
+struct TourSegment: Codable, Identifiable {
+    let id: Int64
+    let title: String
+    let dayIndex: Int
+    let stops: [TourStop]
+}
+
+struct TourStop: Codable {
+    let ord: Int
+    let placeId: Int64
+    let name: String
+    let category: Category
+}

--- a/Walk Munich/Core/Data/Service/ToursService.swift
+++ b/Walk Munich/Core/Data/Service/ToursService.swift
@@ -1,0 +1,51 @@
+//
+//  ToursService.swift
+//  Walk Munich
+//
+
+import Foundation
+
+enum ToursError: LocalizedError {
+    case fileNotFound(String)
+    case decodingFailed(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .fileNotFound(let name): return "Tour data file '\(name)' not found."
+        case .decodingFailed(let error): return "Failed to load tour: \(error.localizedDescription)"
+        }
+    }
+}
+
+struct ToursService {
+    func loadTours(cityId: Int64 = 1) async throws -> [TourSummary] {
+        try await Task.detached(priority: .userInitiated) {
+            let name = "routes_\(cityId)"
+            guard let url = Bundle.main.url(forResource: name, withExtension: "json") else {
+                throw ToursError.fileNotFound(name)
+            }
+            do {
+                let data = try Data(contentsOf: url)
+                let response = try JSONDecoder().decode(ToursResponse.self, from: data)
+                return response.routes
+            } catch let e as DecodingError {
+                throw ToursError.decodingFailed(e)
+            }
+        }.value
+    }
+
+    func loadTourDetail(id: Int64) async throws -> TourDetail {
+        try await Task.detached(priority: .userInitiated) {
+            let name = "route_detail_\(id)"
+            guard let url = Bundle.main.url(forResource: name, withExtension: "json") else {
+                throw ToursError.fileNotFound(name)
+            }
+            do {
+                let data = try Data(contentsOf: url)
+                return try JSONDecoder().decode(TourDetail.self, from: data)
+            } catch let e as DecodingError {
+                throw ToursError.decodingFailed(e)
+            }
+        }.value
+    }
+}

--- a/Walk Munich/Features/Explore/UI/ExploreNavigation.swift
+++ b/Walk Munich/Features/Explore/UI/ExploreNavigation.swift
@@ -25,6 +25,8 @@ struct ExploreNavigation: View {
                     PlaceDetailView(placeId: id)
                 case .allPlaces:
                     AllPlacesView(viewModel: viewModel, path: $path)
+                case .tourDetail(_):
+                    EmptyView()
                 }
             }
         }

--- a/Walk Munich/Features/Favorites/FavoritesNavigation.swift
+++ b/Walk Munich/Features/Favorites/FavoritesNavigation.swift
@@ -17,6 +17,8 @@ struct FavoritesNavigation: View {
                         PlaceDetailView(placeId: id)
                     case .allPlaces:
                         EmptyView()
+                    case .tourDetail(_):
+                        EmptyView()
                     }
                 }
         }

--- a/Walk Munich/Features/Tours/TourDetailView.swift
+++ b/Walk Munich/Features/Tours/TourDetailView.swift
@@ -1,0 +1,303 @@
+//
+//  TourDetailView.swift
+//  Walk Munich
+//
+
+import SwiftUI
+
+struct TourDetailView: View {
+    @State private var viewModel: TourDetailViewModel
+    @Environment(\.dismiss) private var dismiss
+    let onStopTap: (Int64) -> Void
+
+    init(tourId: Int64, onStopTap: @escaping (Int64) -> Void = { _ in }) {
+        _viewModel = State(initialValue: TourDetailViewModel(tourId: tourId))
+        self.onStopTap = onStopTap
+    }
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let errorMessage = viewModel.error {
+                VStack(spacing: Spacing.medium) {
+                    Text(errorMessage)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                    Button(String(localized: "retry")) {
+                        Task { await viewModel.loadTourDetail() }
+                    }
+                }
+                .padding(Spacing.large)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let detail = viewModel.tourDetail {
+                TourDetailContent(detail: detail, onBack: { dismiss() }, onStopTap: onStopTap)
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+        .navigationTitle("")
+        .toolbarBackground(.hidden, for: .navigationBar)
+    }
+}
+
+// MARK: - Content
+
+private struct TourDetailContent: View {
+    let detail: TourDetail
+    let onBack: () -> Void
+    var onStopTap: ((Int64) -> Void)?
+
+    var body: some View {
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: 0) {
+
+                    ZStack(alignment: .top) {
+                        heroImage
+                            .frame(height: 280)
+                            .clipped()
+
+                        LinearGradient(
+                            colors: [.black.opacity(0.5), .clear],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 280)
+
+                        HStack {
+                            CircleTourButton(systemImage: "chevron.left", action: onBack)
+                            Spacer()
+                        }
+                        .padding(.horizontal, Spacing.medium)
+                        .padding(.top, proxy.safeAreaInsets.top + Spacing.extraSmall)
+                    }
+
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        VStack(alignment: .leading, spacing: Spacing.small) {
+                            Text(detail.title)
+                                .font(.title2.bold())
+
+                            if let summary = detail.summary, !summary.isEmpty {
+                                Text(summary)
+                                    .font(.body)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                        .padding(.horizontal, Spacing.large)
+                        .padding(.top, Spacing.large)
+                        .padding(.bottom, Spacing.medium)
+
+                        Divider()
+                            .padding(.horizontal, Spacing.large)
+
+                        // Itinerary
+                        VStack(alignment: .leading, spacing: 0) {
+                            HStack(spacing: Spacing.small) {
+                                Image(systemName: "map")
+                                    .font(.subheadline)
+                                    .foregroundStyle(WalkMunichTheme.primary)
+                                Text("tour_itinerary")
+                                    .font(.headline)
+                            }
+                            .padding(.horizontal, Spacing.large)
+                            .padding(.vertical, Spacing.medium)
+
+                            ForEach(detail.segments) { segment in
+                                ItinerarySegmentView(
+                                    segment: segment,
+                                    showDayHeader: detail.segments.count > 1,
+                                    onStopTap: onStopTap
+                                )
+                            }
+                        }
+                    }
+                    .background(Color(.systemBackground))
+                    .clipShape(UnevenRoundedRectangle(topLeadingRadius: 28, topTrailingRadius: 28))
+                    .offset(y: -24)
+                    .padding(.bottom, -24)
+                }
+            }
+            .ignoresSafeArea(edges: .top)
+        }
+    }
+
+    private var heroImage: some View {
+        Group {
+            if let imageUrl = detail.imageUrl, UIImage(named: imageUrl) != nil {
+                Image(imageUrl)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                PlaceholderImageView()
+            }
+        }
+    }
+}
+
+// MARK: - Itinerary Segment
+
+private struct ItinerarySegmentView: View {
+    let segment: TourSegment
+    let showDayHeader: Bool
+    var onStopTap: ((Int64) -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if showDayHeader {
+                HStack(spacing: Spacing.small) {
+                    Image(systemName: "calendar")
+                        .font(.subheadline)
+                        .foregroundStyle(WalkMunichTheme.primary)
+                    Text(segment.title)
+                        .font(.subheadline.bold())
+                        .foregroundStyle(WalkMunichTheme.primary)
+                }
+                .padding(.horizontal, Spacing.large)
+                .padding(.bottom, Spacing.medium)
+            }
+
+            ForEach(Array(segment.stops.enumerated()), id: \.element.ord) { index, stop in
+                StopRow(
+                    stop: stop,
+                    stepNumber: index + 1,
+                    isLast: index == segment.stops.count - 1,
+                    onTap: onStopTap.map { tap in { tap(stop.placeId) } }
+                )
+            }
+        }
+        .padding(.bottom, Spacing.medium)
+    }
+}
+
+// MARK: - Stop Row
+
+private struct StopRow: View {
+    let stop: TourStop
+    let stepNumber: Int
+    let isLast: Bool
+    var onTap: (() -> Void)?
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Spacing.medium) {
+            // Step number + dashed connector
+            VStack(spacing: 0) {
+                ZStack {
+                    Circle()
+                        .fill(WalkMunichTheme.primary)
+                        .frame(width: 32, height: 32)
+                    Text("\(stepNumber)")
+                        .font(.caption.bold())
+                        .foregroundStyle(.white)
+                }
+
+                if !isLast {
+                    DashedVerticalLine()
+                        .frame(width: 2)
+                        .frame(maxHeight: .infinity)
+                        .padding(.vertical, Spacing.extraSmall)
+                }
+            }
+            .frame(width: 32)
+
+            Button(action: { onTap?() }) {
+                StopCard(stop: stop)
+            }
+            .buttonStyle(.plain)
+            .disabled(onTap == nil)
+            .padding(.bottom, isLast ? 0 : Spacing.medium)
+        }
+        .padding(.horizontal, Spacing.large)
+        .padding(.bottom, isLast ? Spacing.small : 0)
+    }
+}
+
+// MARK: - Stop Card
+
+private struct StopCard: View {
+    let stop: TourStop
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ZStack(alignment: .topTrailing) {
+                stopImage
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 110)
+                    .clipped()
+
+                Image(systemName: stop.category.ui.systemImageName)
+                    .font(.caption.bold())
+                    .foregroundStyle(.white)
+                    .padding(Spacing.extraSmall)
+                    .background(Color.black.opacity(0.3))
+                    .clipShape(Circle())
+                    .padding(Spacing.small)
+            }
+
+            Text(stop.name)
+                .font(.subheadline.bold())
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .padding(.horizontal, Spacing.small)
+                .padding(.vertical, Spacing.small)
+        }
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(Color(.systemGray4).opacity(0.5), lineWidth: 1)
+        )
+        .frame(maxWidth: .infinity)
+    }
+
+    private var stopImage: some View {
+        Group {
+            if UIImage(named: stop.name.lowercased().replacingOccurrences(of: " ", with: "_")) != nil {
+                Image(stop.name.lowercased().replacingOccurrences(of: " ", with: "_"))
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                PlaceholderImageView()
+            }
+        }
+    }
+}
+
+// MARK: - Dashed Line
+
+private struct DashedVerticalLine: View {
+    var body: some View {
+        Canvas { context, size in
+            var path = Path()
+            path.move(to: CGPoint(x: size.width / 2, y: 0))
+            path.addLine(to: CGPoint(x: size.width / 2, y: size.height))
+            context.stroke(
+                path,
+                with: .color(WalkMunichTheme.primary.opacity(0.4)),
+                style: StrokeStyle(lineWidth: 2, dash: [6, 6])
+            )
+        }
+    }
+}
+
+// MARK: - Circle Button
+
+private struct CircleTourButton: View {
+    let systemImage: String
+    var tint: Color = .white
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.callout.bold())
+                .foregroundStyle(tint)
+                .padding(Spacing.small)
+                .frame(width: 40, height: 40)
+                .background(Color.black.opacity(0.15))
+                .clipShape(Circle())
+        }
+    }
+}

--- a/Walk Munich/Features/Tours/ToursNavigation.swift
+++ b/Walk Munich/Features/Tours/ToursNavigation.swift
@@ -9,9 +9,25 @@
 import SwiftUI
 
 struct ToursNavigation: View {
+    @State private var path = NavigationPath()
+
     var body: some View {
-        NavigationStack {
-            ToursView()
+        NavigationStack(path: $path) {
+            ToursView(onTourTap: { id in
+                path.append(Route.tourDetail(id))
+            })
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .tourDetail(let id):
+                    TourDetailView(tourId: id) { placeId in
+                        path.append(Route.placeDetail(placeId))
+                    }
+                case .placeDetail(let id):
+                    PlaceDetailView(placeId: id)
+                case .allPlaces:
+                    EmptyView()
+                }
+            }
         }
     }
 }

--- a/Walk Munich/Features/Tours/ToursView.swift
+++ b/Walk Munich/Features/Tours/ToursView.swift
@@ -5,11 +5,122 @@
 //  Created by Eylul Naz Can on 24.01.2026.
 //
 
-
 import SwiftUI
 
 struct ToursView: View {
+    @State private var viewModel = ToursViewModel()
+    let onTourTap: (Int64) -> Void
+
     var body: some View {
-        Text("Tours")
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let errorMessage = viewModel.error {
+                VStack(spacing: Spacing.medium) {
+                    Text(errorMessage)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                    Button(String(localized: "retry")) {
+                        Task { await viewModel.loadTours() }
+                    }
+                }
+                .padding(Spacing.large)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                toursList
+            }
+        }
+        .navigationTitle("tab_tours")
+        .navigationBarTitleDisplayMode(.large)
+    }
+
+    private var toursList: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                VStack(alignment: .leading, spacing: Spacing.small) {
+                    Text("tour_header_title")
+                        .font(.headline)
+                    Text("tour_header_subtitle")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.horizontal, Spacing.medium)
+                .padding(.top, Spacing.small)
+
+                LazyVStack(spacing: Spacing.medium) {
+                    ForEach(viewModel.tours) { tour in
+                        TourCard(tour: tour) {
+                            onTourTap(tour.id)
+                        }
+                    }
+                }
+                .padding(.horizontal, Spacing.medium)
+            }
+            .padding(.bottom, Spacing.large)
+        }
+    }
+}
+
+// MARK: - Tour Card
+
+private struct TourCard: View {
+    let tour: TourSummary
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 0) {
+                ZStack(alignment: .bottomLeading) {
+                    tourImage
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 180)
+                        .clipped()
+
+                    LinearGradient(
+                        colors: [.clear, .black.opacity(0.65)],
+                        startPoint: .center,
+                        endPoint: .bottom
+                    )
+                    .frame(height: 180)
+
+                    Text(tour.title)
+                        .font(.title3.bold())
+                        .foregroundStyle(.white)
+                        .padding(Spacing.medium)
+                }
+
+                if let summary = tour.summary, !summary.isEmpty {
+                    Text(summary)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .padding(.horizontal, Spacing.medium)
+                        .padding(.vertical, Spacing.small)
+                }
+            }
+            .background(Color(.systemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(Color(.systemGray4).opacity(0.5), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var tourImage: some View {
+        Group {
+            if let imageUrl = tour.imageUrl, UIImage(named: imageUrl) != nil {
+                Image(imageUrl)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                PlaceholderImageView()
+                //Image("hero_munich").resizable().aspectRatio(contentMode: .fill)
+            }
+        }
     }
 }

--- a/Walk Munich/Features/Tours/ViewModel/TourDetailViewModel.swift
+++ b/Walk Munich/Features/Tours/ViewModel/TourDetailViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  TourDetailViewModel.swift
+//  Walk Munich
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class TourDetailViewModel {
+    private(set) var tourDetail: TourDetail?
+    private(set) var isLoading = true
+    private(set) var error: String?
+
+    private let tourId: Int64
+    private let service = ToursService()
+
+    init(tourId: Int64) {
+        self.tourId = tourId
+        Task { await loadTourDetail() }
+    }
+
+    func loadTourDetail() async {
+        isLoading = true
+        error = nil
+        do {
+            tourDetail = try await service.loadTourDetail(id: tourId)
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+}

--- a/Walk Munich/Features/Tours/ViewModel/ToursViewModel.swift
+++ b/Walk Munich/Features/Tours/ViewModel/ToursViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  ToursViewModel.swift
+//  Walk Munich
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class ToursViewModel {
+    private(set) var tours: [TourSummary] = []
+    private(set) var isLoading = true
+    private(set) var error: String?
+
+    private let service = ToursService()
+
+    init() {
+        Task { await loadTours() }
+    }
+
+    func loadTours() async {
+        isLoading = true
+        error = nil
+        do {
+            tours = try await service.loadTours()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+}

--- a/Walk Munich/Navigation/Route.swift
+++ b/Walk Munich/Navigation/Route.swift
@@ -8,4 +8,5 @@
 enum Route: Hashable {
     case placeDetail(Int64)
     case allPlaces
+    case tourDetail(Int64)
 }

--- a/Walk Munich/Resources/Localizable.strings
+++ b/Walk Munich/Resources/Localizable.strings
@@ -33,6 +33,11 @@
 "highlights" = "Highlights";
 "fun_facts" = "Fun Facts";
 
+/* Tours */
+"tour_header_title" = "Explore Munich Your Way";
+"tour_header_subtitle" = "Choose an itinerary and discover the city's best places at your own pace.";
+"tour_itinerary" = "Itinerary";
+
 /* Categories */
 "category_attraction" = "Attraction";
 "category_museum" = "Museum";


### PR DESCRIPTION
Implements the full Tours feature for the iOS app, matching the Android implementation with additional iOS-native            enhancements.                                                                                                                
                                                                                                        
                                                                                                                               
  Data layer                                                                                                                   
  - Tour.swift — TourSummary, TourDetail, TourSegment, TourStop models                                                         
  - ToursService.swift — loads routes_1.json (list) and route_detail_<id>.json (detail) from the app bundle                    
                                                                                                                             
  ViewModels                                                                                                                   
  - ToursViewModel —  VM for the tours list                                                                       
  - TourDetailViewModel — VM for tour detail, loaded by tour ID                                                    
                                                                                                                             
  Tours list screen                                                                                                            
  - Intro header with title and subtitle                                                                                     
  - Full-width image cards with gradient overlay and title pinned to the bottom of the image 
  - Summary text below each card                                                                                               
                                                                                                                             
  Tour detail screen                                                                                                           
  - Hero image extends behind the status bar with a back button that scrolls with the content — consistent 
  with PlaceDetailView                                                                                                         
  - Tour title and summary                                                                                                     
  - Itinerary section with map icon header                                                                                     
  - Multi-day segment support with calendar icon headers (only shown when > 1 segment)                                         
  - Stop cards with category badge, tappable to navigate to Place Detail                                                       
  - Dashed vertical connector line between stops drawn with SwiftUI Canvas                                                     
                                                                                                                               
  Navigation                                                                                                                   
  - Route.tourDetail added to the shared Route enum                                                                     
  - ToursNavigation wires the full stack: Tours list → Tour Detail → Place Detail                                              

<img width="200" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-27 at 02 31 06" src="https://github.com/user-attachments/assets/c1c8174a-bd47-4f15-b5ec-205bf9643a82" />
<img width="200" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-27 at 02 31 09" src="https://github.com/user-attachments/assets/0a32d5ff-e58f-4a89-b830-167dcbf0ced4" />
