### PR TITLE
 Feature: Setting Screen

### DIFF
--- a/Walk Munich/App/Walk_MunichApp.swift
+++ b/Walk Munich/App/Walk_MunichApp.swift
@@ -9,10 +9,13 @@ import SwiftUI
 
 @main
 struct Walk_MunichApp: App {
+    @AppStorage("isDarkMode") private var isDarkMode = false
+
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .tint(WalkMunichTheme.primary)
+                .preferredColorScheme(isDarkMode ? .dark : .light)
         }
     }
 }

--- a/Walk Munich/Core/Data/Service/UserPreferencesService.swift
+++ b/Walk Munich/Core/Data/Service/UserPreferencesService.swift
@@ -45,4 +45,14 @@ final class UserPreferencesService {
         recentlyViewedPlaceIds = Array(ids.prefix(6))
         UserDefaults.standard.set(recentlyViewedPlaceIds, forKey: recentlyViewedKey)
     }
+
+    func clearRecentlyViewed() {
+        recentlyViewedPlaceIds = []
+        UserDefaults.standard.removeObject(forKey: recentlyViewedKey)
+    }
+
+    func clearFavorites() {
+        favoritePlaceIds = []
+        UserDefaults.standard.removeObject(forKey: favoritesKey)
+    }
 }

--- a/Walk Munich/Features/Settings/AboutView.swift
+++ b/Walk Munich/Features/Settings/AboutView.swift
@@ -1,0 +1,61 @@
+//
+//  AboutView.swift
+//  Walk Munich
+//
+
+import SwiftUI
+
+struct AboutView: View {
+    let onDetailTap: (String, String) -> Void
+
+    private let items: [(title: String, contentKey: String)] = [
+        (String(localized: "about_app_description_title"), "about_app_description_content"),
+        (String(localized: "about_disclaimer_title"),      "about_disclaimer_content"),
+        (String(localized: "about_attribution_title"),     "about_attribution_content"),
+        (String(localized: "about_impressum_title"),       "about_impressum_content"),
+    ]
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(items, id: \.title) { item in
+                    Button {
+                        onDetailTap(item.title, String(localized: String.LocalizationValue(item.contentKey)))
+                    } label: {
+                        HStack {
+                            Text(item.title)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+
+            Section {
+                VStack(spacing: Spacing.small) {
+                    Text(appVersion)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Text("about_footer")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .listRowBackground(Color.clear)
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("settings_about_app")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var appVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+        return "Version \(version) (\(build))"
+    }
+}

--- a/Walk Munich/Features/Settings/SettingsNavigation.swift
+++ b/Walk Munich/Features/Settings/SettingsNavigation.swift
@@ -2,16 +2,32 @@
 //  SettingsNavigation.swift
 //  Walk Munich
 //
-//  Created by Eylul Naz Can on 24.01.2026.
-//
-
 
 import SwiftUI
 
+enum SettingsRoute: Hashable {
+    case about
+    case textDetail(title: String, content: String)
+}
+
 struct SettingsNavigation: View {
+    @State private var path = NavigationPath()
+
     var body: some View {
-        NavigationStack {
-            SettingsView()
+        NavigationStack(path: $path) {
+            SettingsView(onAboutTap: {
+                path.append(SettingsRoute.about)
+            })
+            .navigationDestination(for: SettingsRoute.self) { route in
+                switch route {
+                case .about:
+                    AboutView { title, content in
+                        path.append(SettingsRoute.textDetail(title: title, content: content))
+                    }
+                case .textDetail(let title, let content):
+                    TextDetailView(title: title, content: content)
+                }
+            }
         }
     }
 }

--- a/Walk Munich/Features/Settings/SettingsView.swift
+++ b/Walk Munich/Features/Settings/SettingsView.swift
@@ -2,18 +2,129 @@
 //  SettingsView.swift
 //  Walk Munich
 //
-//  Created by Eylul Naz Can on 24.01.2026.
-//
-
 
 import SwiftUI
 
 struct SettingsView: View {
-    var body: some View {
-        Text("Settings")
-    }
-}
+    @AppStorage("isDarkMode") private var isDarkMode = false
+    @State private var showClearHistoryAlert = false
+    @State private var showClearFavoritesAlert = false
 
-#Preview {
-    SettingsView()
+    private let preferences = UserPreferencesService.shared
+    let onAboutTap: () -> Void
+
+    var body: some View {
+        List {
+            // App header
+            Section {
+                HStack(spacing: Spacing.medium) {
+                    appIcon
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("app_title")
+                            .font(.headline)
+                        Text(appVersion)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.vertical, Spacing.extraSmall)
+                .listRowBackground(Color.clear)
+            }
+
+            // Appearance
+            Section(String(localized: "settings_appearance")) {
+                HStack {
+                    Label("settings_dark_mode", systemImage: "moon")
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Toggle("", isOn: $isDarkMode)
+                        .labelsHidden()
+                }
+            }
+
+            // Data
+            Section(String(localized: "settings_data")) {
+                Button {
+                    showClearHistoryAlert = true
+                } label: {
+                    Label("settings_clear_recently_viewed", systemImage: "clock.arrow.circlepath")
+                }
+                .tint(.primary)
+
+                Button(role: .destructive) {
+                    showClearFavoritesAlert = true
+                } label: {
+                    Label("settings_clear_favorites", systemImage: "heart.slash")
+                }
+            }
+
+            // About
+            Section(String(localized: "settings_about_section")) {
+                Button(action: onAboutTap) {
+                    HStack {
+                        Label("settings_about_app", systemImage: "info.circle")
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                HStack {
+                    Label("settings_version", systemImage: "tag")
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Text(appVersion)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("settings_title")
+        .navigationBarTitleDisplayMode(.large)
+        .alert(String(localized: "settings_clear_recently_viewed"), isPresented: $showClearHistoryAlert) {
+            Button(String(localized: "alert_clear"), role: .destructive) {
+                preferences.clearRecentlyViewed()
+            }
+            Button(String(localized: "alert_cancel"), role: .cancel) {}
+        } message: {
+            Text("alert_clear_recently_viewed_message")
+        }
+        .alert(String(localized: "settings_clear_favorites"), isPresented: $showClearFavoritesAlert) {
+            Button(String(localized: "alert_clear"), role: .destructive) {
+                preferences.clearFavorites()
+            }
+            Button(String(localized: "alert_cancel"), role: .cancel) {}
+        } message: {
+            Text("alert_clear_favorites_message")
+        }
+    }
+
+    private var appVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+        return "\(version) (\(build))"
+    }
+
+    private var appIcon: some View {
+        Group {
+            if let icon = UIImage(named: "AppIcon") {
+                Image(uiImage: icon)
+                    .resizable()
+                    .frame(width: 56, height: 56)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            } else {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(WalkMunichTheme.primary)
+                    .frame(width: 56, height: 56)
+                    .overlay(
+                        Image(systemName: "map")
+                            .font(.title2)
+                            .foregroundStyle(.white)
+                    )
+            }
+        }
+    }
 }

--- a/Walk Munich/Features/Settings/TextDetailView.swift
+++ b/Walk Munich/Features/Settings/TextDetailView.swift
@@ -1,0 +1,23 @@
+//
+//  TextDetailView.swift
+//  Walk Munich
+//
+
+import SwiftUI
+
+struct TextDetailView: View {
+    let title: String
+    let content: String
+
+    var body: some View {
+        ScrollView {
+            Text(content)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(Spacing.large)
+        }
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Walk Munich/Resources/Localizable.strings
+++ b/Walk Munich/Resources/Localizable.strings
@@ -38,6 +38,34 @@
 "tour_header_subtitle" = "Choose an itinerary and discover the city's best places at your own pace.";
 "tour_itinerary" = "Itinerary";
 
+/* Settings */
+"settings_title" = "Settings";
+"settings_appearance" = "Appearance";
+"settings_dark_mode" = "Dark Mode";
+"settings_data" = "Data";
+"settings_clear_recently_viewed" = "Clear Recently Viewed";
+"settings_clear_favorites" = "Clear All Favorites";
+"settings_about_section" = "About";
+"settings_about_app" = "About App";
+"settings_version" = "Version";
+
+/* About */
+"about_app_description_title" = "App Description";
+"about_app_description_content" = "Walk Munich is a curated city guide designed to help you discover interesting places and walking routes while exploring Munich.\n\nThe routes and recommendations presented in the app are personally curated suggestions, based on individual exploration, research, and personal interest.\n\nThe app focuses on walkable experiences, cultural highlights, and local spots, presented in a simple and enjoyable way.";
+"about_disclaimer_title" = "Disclaimer";
+"about_disclaimer_content" = "Walk Munich is a non-commercial, personal project created for learning, experimentation, and portfolio purposes.\n\nIt is not an official city guide and is not affiliated with the City of Munich, local authorities, or any tourism organization.\n\nRoutes, place descriptions, and recommendations reflect personal suggestions and may not be complete, up to date, or suitable for every user.\n\nAll information is provided \"as is\" without any guarantees regarding accuracy or reliability.";
+"about_attribution_title" = "Attribution & Sources";
+"about_attribution_content" = "Images, place information, and background content used in this app come from publicly available sources and open references.\n\nWhere applicable, sources and attributions are included.\n\nIf you believe any content is incorrectly attributed or should be removed, please get in touch.";
+"about_impressum_title" = "Impressum";
+"about_impressum_content" = "Developer: Eylül Naz Can\nPurpose: Personal / educational project\n\nThis app was created for learning, exploration, and portfolio purposes. It is an open-source project licensed under the MIT License.";
+"about_footer" = "An open-source project built with care and a passion for simple, thoughtful design.\n© 2026 Eylül Naz Can · MIT License";
+
+/* Alerts */
+"alert_clear_recently_viewed_message" = "This will remove all recently viewed places from your history.";
+"alert_clear_favorites_message" = "This will remove all your saved favorite places.";
+"alert_clear" = "Clear";
+"alert_cancel" = "Cancel";
+
 /* Categories */
 "category_attraction" = "Attraction";
 "category_museum" = "Museum";


### PR DESCRIPTION
  - Implements the Settings tab 
  - Adds dark mode toggle persisted via `@AppStorage("isDarkMode")`
  - Adds "Clear Recently Viewed" and "Clear All Favorites" actions with confirmation alerts, backed by new                     
  `clearRecentlyViewed()` and `clearFavorites()` methods on `UserPreferencesService`                                           
  - Adds an About section routing to a dedicated `AboutView` with App Description, Disclaimer, Attribution, and Impressum      
  entries — each navigating to a `TextDetailView` for full content                                                             
  - Introduces `SettingsRoute` enum and a `NavigationStack`-based `SettingsNavigation` to handle in-tab navigation
      
<img width="200" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-27 at 22 29 13" src="https://github.com/user-attachments/assets/47c9cb24-2738-4c53-9ad6-d2eeadbbe85c" />
